### PR TITLE
Added single file import support

### DIFF
--- a/bin/commands/files.js
+++ b/bin/commands/files.js
@@ -108,9 +108,14 @@ async function handleFiles(argv) {
             if (argv.recursive) {
                 await processDirectory(env, user, resolvedPath, argv.outPath, files, resolvedPath, argv.createEmpty, true);
             } else {
-                let filesInDir = getFilesInDirectory(resolvedPath);
-                if (files)
-                    filesInDir = getFilesNotInData(filesInDir, files.files.data, resolvedPath);
+                let filesInDir = [];
+                if (fs.existsSync(resolvedPath) && fs.lstatSync(resolvedPath).isDirectory()) {
+                    filesInDir = getFilesInDirectory(resolvedPath)
+                    if (files)
+                        filesInDir = getFilesNotInData(filesInDir, files.files.data, resolvedPath);
+                } else if (fs.existsSync(resolvedPath)) {
+                    filesInDir = [resolvedPath];
+                }
                 await uploadFiles(env, user, filesInDir, argv.outPath, argv.createEmpty);
             }
         }


### PR DESCRIPTION
I have added support for single file import.

So that you can do:
`dw files -i <path>\file.cshtml Templates/Designs/Swift/Paragraph/file.cshtml`

Right now you can only do a: `dw files -i <path>` with folders
Single file upload will result in an error like this:

```
2024-05-31T11:31:40.5866244Z node:fs:1507
2024-05-31T11:31:40.5866742Z   const result = binding.readdir(
2024-05-31T11:31:40.5867312Z                          ^
2024-05-31T11:31:40.5867557Z 
2024-05-31T11:31:40.5868170Z Error: ENOTDIR: not a directory, scandir 'D:\a\r1\a\temp\deployed\Templates\Designs\Swift\Paragraph\file.cshtml'
2024-05-31T11:31:40.5868514Z     at Object.readdirSync (node:fs:1507:26)
2024-05-31T11:31:40.5868851Z     at getFilesInDirectory (file:///C:/npm/prefix/node_modules/@dynamicweb/cli/bin/commands/files.js:134:15)
2024-05-31T11:31:40.5869233Z     at handleFiles (file:///C:/npm/prefix/node_modules/@dynamicweb/cli/bin/commands/files.js:111:34) {
2024-05-31T11:31:40.5869568Z   errno: -4052,
2024-05-31T11:31:40.5869838Z   code: 'ENOTDIR',
2024-05-31T11:31:40.5870127Z   syscall: 'scandir',
2024-05-31T11:31:40.5870469Z   path: 'D:\\a\\r1\\a\\temp\\deployed\\Templates\\Designs\\Swift\\Paragraph\\file.cshtml'
2024-05-31T11:31:40.5870948Z }
```