### PR TITLE
Fixed wildcard replace logic

### DIFF
--- a/bin/commands/files.js
+++ b/bin/commands/files.js
@@ -286,11 +286,8 @@ export function resolveFilePath(filePath) {
     return path.join(p.dir, resolvedPath);
 }
 
+
 function wildcardToRegExp(wildcard) {
-    return new RegExp('^' + wildcard
-      .replace(/\./g, '\\.')
-      .replace(/\*/g, '.*')
-      .replace(/\+/g, '.+')
-      .replace(/\?/g, '.')
-      + '$');
+    return new RegExp('^' + wildcard.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$');
 }
+


### PR DESCRIPTION
Wildcards did not translate correctly to regex as not all escape characters were handled.