### PR TITLE
DW CLI doesn't resolve folder paths as expected in certain terminals/shells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+/.vs

--- a/README.md
+++ b/README.md
@@ -169,3 +169,33 @@ Config is used to manage the .dwc file through the CLI, given any prop it will c
 #### Examples
 Changing the host for the dev environment
 > $ dw config --env.dev.host localhost:6001
+
+## Using Git Bash
+If you're using Git Bash, you may encounter issues with path conversion that can interfere with relative paths used in commands.
+
+### Path Conversion Issues
+Git Bash automatically converts relative paths to absolute paths, which can cause problems. 
+You'll see a warning message if the conversion setting is not disabled:
+
+"You appear to have path conversion turned on in your shell. If you are using relative paths, this may interfere. Please see doc.dynamicweb.dev for more information."
+
+### Solution
+To resolve this issue, disable path conversion by setting the `MSYS_NO_PATHCONV` environment variable (current session only):
+
+> $ export MSYS_NO_PATHCONV=1
+
+#### Examples
+
+> $ export MSYS_NO_PATHCONV=1
+> $ dw files -iro ./ /TestFolder --host \<host\> --apiKey \<apiKey\>
+
+### Alternative Solutions
+If you prefer not to disable path conversion globally, you can:
+
+1. Prefix problematic paths with `//` to prevent conversion for specific commands.
+2. Use PowerShell or CMD instead of Git Bash.
+
+#### Examples
+
+> $ dw files -iro ./ //TestFolder --host \<host\> --apiKey \<apiKey\>
+

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ If you're using Git Bash, you may encounter issues with path conversion that can
 Git Bash automatically converts relative paths to absolute paths, which can cause problems. 
 You'll see a warning message if the conversion setting is not disabled:
 
-"You appear to have path conversion turned on in your shell. If you are using relative paths, this may interfere. Please see doc.dynamicweb.dev for more information."
+"You appear to have path conversion turned on in your shell. 
+If you are using relative paths, this may interfere. 
+Please see https://doc.dynamicweb.dev/documentation/fundamentals/code/CLI.html for more information."
 
 ### Solution
 To resolve this issue, disable path conversion by setting the `MSYS_NO_PATHCONV` environment variable (current session only):
@@ -192,10 +194,9 @@ To resolve this issue, disable path conversion by setting the `MSYS_NO_PATHCONV`
 ### Alternative Solutions
 If you prefer not to disable path conversion globally, you can:
 
-1. Prefix problematic paths with `//` to prevent conversion for specific commands.
+1. Prefix relative paths with `./` instead of just `/` to prevent conversion for specific commands.
 2. Use PowerShell or CMD instead of Git Bash.
 
 #### Examples
 
-> $ dw files -iro ./ //TestFolder --host \<host\> --apiKey \<apiKey\>
-
+> $ dw files -iro ./ ./TestFolder --host \<host\> --apiKey \<apiKey\>

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ import { queryCommand } from './commands/query.js';
 import { commandCommand } from './commands/command.js';
 
 setupConfig();
+showGitBashRelativePathWarning();
 
 yargs(hideBin(process.argv))
     .scriptName('dw')
@@ -57,5 +58,16 @@ function baseCommand() {
             console.log(`Protocol: ${getConfig()?.env[getConfig()?.current?.env]?.protocol}`)
             console.log(`Host: ${getConfig()?.env[getConfig()?.current?.env]?.host}`)
         }
+    }
+}
+
+function showGitBashRelativePathWarning() {
+    const isGitBash = !!process.env.MSYSTEM;
+    const pathConversionDisabled = process.env.MSYS_NO_PATHCONV === '1';
+
+    if (isGitBash && !pathConversionDisabled) {
+        console.warn('You appear to have path conversion turned on in your shell.');
+        console.warn('If you are using relative paths, this may interfere.');
+        console.warn('Please see doc.dynamicweb.dev for more information.');
     }
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -68,6 +68,6 @@ function showGitBashRelativePathWarning() {
     if (isGitBash && !pathConversionDisabled) {
         console.warn('You appear to have path conversion turned on in your shell.');
         console.warn('If you are using relative paths, this may interfere.');
-        console.warn('Please see doc.dynamicweb.dev for more information.');
+        console.warn('Please see https://doc.dynamicweb.dev/documentation/fundamentals/code/CLI.html for more information.');
     }
 }


### PR DESCRIPTION
The original task:
https://dev.azure.com/dynamicwebsoftware/Dynamicweb/_workitems/edit/25797

Added warning which shows when open CLI from Git Bash with enabled path conversion setting.
Updated documentation to aware customer about Git Bash features.

Git Bash automatically converts the paths which starts from "/", so instead of for example "/Test", we will get "C:/Program Files/Git/Test". We can't do anything with it. The customer must disable the conversion setting in their Git Bash or use "//" instead of single "/".